### PR TITLE
Make table names configurable with ai_ prefix

### DIFF
--- a/config/converse.php
+++ b/config/converse.php
@@ -11,12 +11,12 @@ return [
     |
     */
     'tables' => [
-        'conversations' => 'conversations',
-        'messages' => 'messages',
-        'message_chunks' => 'message_chunks',
-        'message_attachments' => 'message_attachments',
+        'conversations' => 'ai_conversations',
+        'messages' => 'ai_messages',
+        'message_chunks' => 'ai_message_chunks',
+        'message_attachments' => 'ai_message_attachments',
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Model Classes
@@ -32,7 +32,7 @@ return [
         'message_chunk' => \ElliottLawson\Converse\Models\MessageChunk::class,
         'message_attachment' => \ElliottLawson\Converse\Models\MessageAttachment::class,
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Storage Configuration
@@ -45,7 +45,7 @@ return [
         'disk' => env('CONVERSE_DISK', 'local'),
         'path' => env('CONVERSE_PATH', 'conversations'),
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Cleanup Configuration
@@ -56,7 +56,7 @@ return [
     |
     */
     'prune_after_days' => env('CONVERSE_PRUNE_DAYS', null),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Broadcasting Configuration

--- a/database/migrations/2025_12_06_000001_create_conversations_table.php
+++ b/database/migrations/2025_12_06_000001_create_conversations_table.php
@@ -8,7 +8,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('conversations', function (Blueprint $table) {
+        Schema::create(config('converse.tables.conversations'), function (Blueprint $table) {
             $table->id();
             $table->uuid('uuid')->unique();
             $table->nullableMorphs('conversable');
@@ -17,13 +17,13 @@ return new class extends Migration
             $table->json('context')->nullable();
             $table->timestamps();
             $table->softDeletes();
-            
+
             $table->index('created_at');
         });
     }
 
     public function down(): void
     {
-        Schema::dropIfExists('conversations');
+        Schema::dropIfExists(config('converse.tables.conversations'));
     }
 };

--- a/database/migrations/2025_12_06_000002_create_messages_table.php
+++ b/database/migrations/2025_12_06_000002_create_messages_table.php
@@ -8,9 +8,9 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('messages', function (Blueprint $table) {
+        Schema::create(config('converse.tables.messages'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId('conversation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('conversation_id')->constrained(config('converse.tables.conversations'))->cascadeOnDelete();
             $table->enum('role', ['user', 'assistant', 'system', 'tool_call', 'tool_result']);
             $table->text('content')->nullable();
             $table->json('metadata')->nullable();
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->timestamp('completed_at')->nullable();
             $table->timestamps();
             $table->softDeletes();
-            
+
             $table->index(['conversation_id', 'created_at']);
             $table->index('role');
             $table->index('status');
@@ -28,6 +28,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('messages');
+        Schema::dropIfExists(config('converse.tables.messages'));
     }
 };

--- a/database/migrations/2025_12_06_000003_create_message_chunks_table.php
+++ b/database/migrations/2025_12_06_000003_create_message_chunks_table.php
@@ -8,14 +8,14 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('message_chunks', function (Blueprint $table) {
+        Schema::create(config('converse.tables.message_chunks'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId('message_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('message_id')->constrained(config('converse.tables.messages'))->cascadeOnDelete();
             $table->text('content');
             $table->integer('sequence');
             $table->json('metadata')->nullable();
             $table->timestamp('created_at');
-            
+
             $table->unique(['message_id', 'sequence']);
             $table->index(['message_id', 'sequence']);
         });
@@ -23,6 +23,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('message_chunks');
+        Schema::dropIfExists(config('converse.tables.message_chunks'));
     }
 };

--- a/database/migrations/2025_12_06_000004_create_message_attachments_table.php
+++ b/database/migrations/2025_12_06_000004_create_message_attachments_table.php
@@ -8,22 +8,22 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('message_attachments', function (Blueprint $table) {
+        Schema::create(config('converse.tables.message_attachments'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId('message_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('message_id')->constrained(config('converse.tables.messages'))->cascadeOnDelete();
             $table->string('type');
             $table->string('path');
             $table->string('mime_type')->nullable();
             $table->integer('size')->nullable();
             $table->json('metadata')->nullable();
             $table->timestamps();
-            
+
             $table->index(['message_id', 'type']);
         });
     }
 
     public function down(): void
     {
-        Schema::dropIfExists('message_attachments');
+        Schema::dropIfExists(config('converse.tables.message_attachments'));
     }
 };

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -17,32 +17,37 @@ use Illuminate\Support\Collection;
 class Conversation extends Model
 {
     use HasFactory, HasUuids, SoftDeletes;
-    
+
     protected $fillable = [
         'title',
         'metadata',
         'context',
     ];
-    
+
+    public function getTable()
+    {
+        return config('converse.tables.conversations');
+    }
+
     public function uniqueIds(): array
     {
         return ['uuid'];
     }
-    
+
     protected static function newFactory()
     {
         return \ElliottLawson\Converse\Database\Factories\ConversationFactory::new();
     }
-    
+
     protected $casts = [
         'metadata' => 'array',
         'context' => 'array',
     ];
-    
+
     protected $dispatchesEvents = [
         'created' => ConversationCreated::class,
     ];
-    
+
     protected static function booted(): void
     {
         static::deleting(function (Conversation $conversation) {
@@ -52,27 +57,27 @@ class Conversation extends Model
                 $conversation->messages()->delete();
             }
         });
-        
+
         static::restoring(function (Conversation $conversation) {
             $conversation->messages()->withTrashed()->restore();
         });
     }
-    
+
     public function conversable(): MorphTo
     {
         return $this->morphTo();
     }
-    
+
     public function messages(): HasMany
     {
         return $this->hasMany(Message::class)->orderBy('created_at');
     }
-    
+
     public function lastMessage(): HasOne
     {
         return $this->hasOne(Message::class)->latestOfMany();
     }
-    
+
     public function addMessage(MessageRole $role, ?string $content = null, array $metadata = []): Message
     {
         return $this->messages()->create([
@@ -80,40 +85,40 @@ class Conversation extends Model
             'content' => $content,
             'metadata' => $metadata,
             'status' => MessageStatus::Success,
-            'is_complete' => !empty($content),
-            'completed_at' => !empty($content) ? now() : null,
+            'is_complete' => ! empty($content),
+            'completed_at' => ! empty($content) ? now() : null,
         ]);
     }
-    
+
     public function addUserMessage(string $content, array $metadata = []): Message
     {
         return $this->addMessage(MessageRole::User, $content, $metadata);
     }
-    
+
     public function addAssistantMessage(string $content, array $metadata = []): Message
     {
         return $this->addMessage(MessageRole::Assistant, $content, $metadata);
     }
-    
+
     public function addSystemMessage(string $content, array $metadata = []): Message
     {
         return $this->addMessage(MessageRole::System, $content, $metadata);
     }
-    
+
     public function addToolCallMessage(string $content, array $metadata = []): Message
     {
         return $this->addMessage(MessageRole::ToolCall, $content, $metadata);
     }
-    
+
     public function addToolResultMessage(string $content, array $metadata = []): Message
     {
         return $this->addMessage(MessageRole::ToolResult, $content, $metadata);
     }
-    
+
     public function startStreamingMessage(MessageRole $role, array $metadata = []): Message
     {
         $metadata['streamed'] = true;
-        
+
         return $this->messages()->create([
             'role' => $role,
             'content' => '',
@@ -122,26 +127,26 @@ class Conversation extends Model
             'is_complete' => false,
         ]);
     }
-    
+
     public function startStreamingAssistant(array $metadata = []): Message
     {
         return $this->startStreamingMessage(MessageRole::Assistant, $metadata);
     }
-    
+
     public function startStreamingUser(array $metadata = []): Message
     {
         return $this->startStreamingMessage(MessageRole::User, $metadata);
     }
-    
+
     public function addMessages(...$messages): Collection
     {
         // If first argument is an array and it's the only argument, use it as the messages
         if (count($messages) === 1 && is_array($messages[0])) {
             $messages = $messages[0];
         }
-        
+
         $createdMessages = collect();
-        
+
         foreach ($messages as $message) {
             // Handle different formats
             if (is_string($message)) {
@@ -153,19 +158,19 @@ class Conversation extends Model
                     $data = $message->toArray();
                     $createdMessages->push($this->addMessage($data['role'], $data['content'], $data['metadata'] ?? []));
                 } else {
-                    throw new \InvalidArgumentException("Unknown message object type: " . get_class($message));
+                    throw new \InvalidArgumentException('Unknown message object type: '.get_class($message));
                 }
             } elseif (isset($message['role']) && isset($message['content'])) {
                 // Array with role and content
                 $role = $message['role'] instanceof MessageRole ? $message['role'] : MessageRole::from($message['role']);
                 $metadata = $message['metadata'] ?? [];
-                
+
                 $createdMessages->push($this->addMessage($role, $message['content'], $metadata));
             } elseif (isset($message['type']) && isset($message['content'])) {
                 // Alternative format with type
                 $metadata = $message['metadata'] ?? [];
-                
-                $createdMessages->push(match($message['type']) {
+
+                $createdMessages->push(match ($message['type']) {
                     'user' => $this->addUserMessage($message['content'], $metadata),
                     'assistant' => $this->addAssistantMessage($message['content'], $metadata),
                     'system' => $this->addSystemMessage($message['content'], $metadata),
@@ -175,7 +180,7 @@ class Conversation extends Model
                 });
             }
         }
-        
+
         return $createdMessages;
     }
 }

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -5,10 +5,10 @@ namespace ElliottLawson\Converse\Models;
 use ElliottLawson\Converse\Database\Factories\MessageFactory;
 use ElliottLawson\Converse\Enums\MessageRole;
 use ElliottLawson\Converse\Enums\MessageStatus;
+use ElliottLawson\Converse\Events\ChunkReceived;
+use ElliottLawson\Converse\Events\MessageCompleted;
 use ElliottLawson\Converse\Events\MessageCreated;
 use ElliottLawson\Converse\Events\MessageUpdated;
-use ElliottLawson\Converse\Events\MessageCompleted;
-use ElliottLawson\Converse\Events\ChunkReceived;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Message extends Model
 {
     use HasFactory, SoftDeletes;
-    
+
     protected $fillable = [
         'role',
         'content',
@@ -27,7 +27,12 @@ class Message extends Model
         'is_complete',
         'completed_at',
     ];
-    
+
+    public function getTable()
+    {
+        return config('converse.tables.messages');
+    }
+
     protected $casts = [
         'role' => MessageRole::class,
         'status' => MessageStatus::class,
@@ -35,151 +40,151 @@ class Message extends Model
         'is_complete' => 'boolean',
         'completed_at' => 'datetime',
     ];
-    
+
     protected $dispatchesEvents = [
         'created' => MessageCreated::class,
         'updated' => MessageUpdated::class,
     ];
-    
+
     protected static function newFactory(): MessageFactory
     {
         return MessageFactory::new();
     }
-    
+
     public function conversation(): BelongsTo
     {
         return $this->belongsTo(Conversation::class);
     }
-    
+
     public function chunks(): HasMany
     {
         return $this->hasMany(MessageChunk::class)->orderBy('sequence');
     }
-    
+
     public function attachments(): HasMany
     {
         return $this->hasMany(MessageAttachment::class);
     }
-    
+
     public function scopeByRole($query, MessageRole $role)
     {
         return $query->where('role', $role);
     }
-    
+
     public function scopeUser($query)
     {
         return $query->where('role', MessageRole::User);
     }
-    
+
     public function scopeAssistant($query)
     {
         return $query->where('role', MessageRole::Assistant);
     }
-    
+
     public function scopeSystem($query)
     {
         return $query->where('role', MessageRole::System);
     }
-    
+
     public function scopeCompleted($query)
     {
         return $query->where('is_complete', true);
     }
-    
+
     public function scopeStreaming($query)
     {
         return $query->where('is_complete', false);
     }
-    
+
     public function scopeFailed($query)
     {
         return $query->where('status', MessageStatus::Error);
     }
-    
+
     public function appendChunk(string $chunk, array $metadata = []): MessageChunk
     {
         $sequence = $this->chunks()->max('sequence') ?? -1;
-        
+
         $messageChunk = $this->chunks()->create([
             'content' => $chunk,
             'sequence' => $sequence + 1,
             'metadata' => $metadata,
         ]);
-        
+
         $this->update([
-            'content' => $this->content . $chunk,
+            'content' => $this->content.$chunk,
         ]);
-        
+
         event(new ChunkReceived($this, $messageChunk));
-        
+
         return $messageChunk;
     }
-    
+
     public function completeStreaming(array $finalMetadata = []): self
     {
         $metadata = array_merge($this->metadata ?? [], $finalMetadata);
         $metadata['chunks'] = $this->chunks()->count();
-        
+
         $this->update([
             'is_complete' => true,
             'completed_at' => now(),
             'status' => MessageStatus::Success,
             'metadata' => $metadata,
         ]);
-        
+
         event(new MessageCompleted($this));
-        
+
         return $this;
     }
-    
+
     public function failStreaming(string $error, array $errorMetadata = []): self
     {
         $metadata = array_merge($this->metadata ?? [], $errorMetadata);
         $metadata['error'] = $error;
         $metadata['chunks'] = $this->chunks()->count();
-        
+
         $this->update([
             'is_complete' => true,
             'completed_at' => now(),
             'status' => MessageStatus::Error,
             'metadata' => $metadata,
         ]);
-        
+
         event(new MessageCompleted($this));
-        
+
         return $this;
     }
-    
+
     public function markAsError(string $error, array $errorMetadata = []): self
     {
         $metadata = array_merge($this->metadata ?? [], $errorMetadata);
         $metadata['error'] = $error;
-        
+
         $this->update([
             'status' => MessageStatus::Error,
             'is_complete' => true,
             'completed_at' => now(),
             'metadata' => $metadata,
         ]);
-        
+
         return $this;
     }
-    
+
     public function isToolCall(): bool
     {
         return $this->role === MessageRole::ToolCall;
     }
-    
+
     public function isToolResult(): bool
     {
         return $this->role === MessageRole::ToolResult;
     }
-    
+
     public function getToolCallId(): ?string
     {
         return $this->metadata['tool_call_id'] ?? null;
     }
-    
+
     public function getToolName(): ?string
     {
         return $this->metadata['tool_name'] ?? null;

--- a/src/Models/MessageAttachment.php
+++ b/src/Models/MessageAttachment.php
@@ -14,12 +14,17 @@ class MessageAttachment extends Model
         'size',
         'metadata',
     ];
-    
+
+    public function getTable()
+    {
+        return config('converse.tables.message_attachments');
+    }
+
     protected $casts = [
         'metadata' => 'array',
         'size' => 'integer',
     ];
-    
+
     public function message(): BelongsTo
     {
         return $this->belongsTo(Message::class);

--- a/src/Models/MessageChunk.php
+++ b/src/Models/MessageChunk.php
@@ -9,25 +9,30 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class MessageChunk extends Model
 {
     use HasFactory;
-    
+
     const UPDATED_AT = null;
-    
+
     protected $fillable = [
         'content',
         'sequence',
         'metadata',
     ];
-    
+
+    public function getTable()
+    {
+        return config('converse.tables.message_chunks');
+    }
+
     protected $casts = [
         'metadata' => 'array',
         'created_at' => 'datetime',
     ];
-    
+
     protected static function newFactory()
     {
         return \ElliottLawson\Converse\Database\Factories\MessageChunkFactory::new();
     }
-    
+
     public function message(): BelongsTo
     {
         return $this->belongsTo(Message::class);


### PR DESCRIPTION
- Update default table names to use ai_ prefix to avoid conflicts
- Add getTable() method to all models to read from config
- Update all migrations to use configurable table names
- Fix foreign key constraints to reference configured table names

This allows users to customize table names via the config file while preventing conflicts with existing tables by default.