### PR TITLE
Add fluent API for conversation building

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,18 +60,51 @@ $conversation = $user->startConversation([
 ```php
 use ElliottLawson\Converse\Models\Conversation;
 
-// User messages
+// Individual messages
 $conversation->addUserMessage('How do I deploy Laravel to production?');
-
-// Assistant responses  
 $conversation->addAssistantMessage('There are several ways to deploy Laravel...');
-
-// System prompts
 $conversation->addSystemMessage('You are a helpful Laravel expert.');
 
 // Tool/Function calls
 $conversation->addToolCallMessage('get_deployment_options(framework="laravel")');
 $conversation->addToolResultMessage('{"options": ["Forge", "Vapor", "Docker"]}');
+
+// Fluent chaining (perfect for building conversation context)
+$conversation
+    ->addSystemMessage('You are a Laravel expert with 10+ years experience')
+    ->addUserMessage('Context: I have a Laravel app that needs deployment')
+    ->addUserMessage('Requirements: High availability, auto-scaling, zero downtime')
+    ->addUserMessage('Question: What deployment strategy do you recommend?');
+```
+
+### Two APIs: Choose What You Need
+
+**Fluent API** - Returns `Conversation` for chaining:
+```php
+$conversation = $conversation
+    ->addSystemMessage('You are helpful')
+    ->addUserMessage('Hello')
+    ->addAssistantMessage('Hi there!');
+```
+
+**Direct API** - Returns `Message` objects when you need immediate access:
+```php
+$message = $conversation->createUserMessage('Hello');
+$messageId = $message->id;
+$content = $message->content;
+```
+
+### Helper Methods
+
+```php
+// Get the most recently added message
+$lastMessage = $conversation->getLastMessage();
+
+// Get recent messages as a collection
+$recentMessages = $conversation->getRecentMessages(5);
+
+// Create a conversation subset with recent messages (useful for context windows)
+$subset = $conversation->selectRecentMessages(10);
 ```
 
 ### Bulk Importing Messages

--- a/tests/Feature/BulkMessageTest.php
+++ b/tests/Feature/BulkMessageTest.php
@@ -13,12 +13,12 @@ it('can add multiple messages as simple strings', function () {
     ]);
 
     expect($messages)->toHaveCount(3)
-        ->and($messages[0]->content)->toBe('Hello, I need help')
-        ->and($messages[0]->role)->toBe(MessageRole::User)
-        ->and($messages[1]->content)->toBe('What seems to be the problem?')
-        ->and($messages[1]->role)->toBe(MessageRole::User)
-        ->and($messages[2]->content)->toBe('My code is not working')
-        ->and($messages[2]->role)->toBe(MessageRole::User);
+        ->and($messages->get(0)->content)->toBe('Hello, I need help')
+        ->and($messages->get(0)->role)->toBe(MessageRole::User)
+        ->and($messages->get(1)->content)->toBe('What seems to be the problem?')
+        ->and($messages->get(1)->role)->toBe(MessageRole::User)
+        ->and($messages->get(2)->content)->toBe('My code is not working')
+        ->and($messages->get(2)->role)->toBe(MessageRole::User);
 });
 
 it('can add messages with role and content', function () {
@@ -31,9 +31,9 @@ it('can add messages with role and content', function () {
     ]);
 
     expect($messages)->toHaveCount(3)
-        ->and($messages[0]->role)->toBe(MessageRole::System)
-        ->and($messages[1]->role)->toBe(MessageRole::User)
-        ->and($messages[2]->role)->toBe(MessageRole::Assistant);
+        ->and($messages->get(0)->role)->toBe(MessageRole::System)
+        ->and($messages->get(1)->role)->toBe(MessageRole::User)
+        ->and($messages->get(2)->role)->toBe(MessageRole::Assistant);
 });
 
 it('can add messages with type format', function () {
@@ -48,11 +48,11 @@ it('can add messages with type format', function () {
     ]);
 
     expect($messages)->toHaveCount(5)
-        ->and($messages[0]->role)->toBe(MessageRole::System)
-        ->and($messages[1]->role)->toBe(MessageRole::User)
-        ->and($messages[2]->role)->toBe(MessageRole::Assistant)
-        ->and($messages[3]->role)->toBe(MessageRole::ToolCall)
-        ->and($messages[4]->role)->toBe(MessageRole::ToolResult);
+        ->and($messages->get(0)->role)->toBe(MessageRole::System)
+        ->and($messages->get(1)->role)->toBe(MessageRole::User)
+        ->and($messages->get(2)->role)->toBe(MessageRole::Assistant)
+        ->and($messages->get(3)->role)->toBe(MessageRole::ToolCall)
+        ->and($messages->get(4)->role)->toBe(MessageRole::ToolResult);
 });
 
 it('can add messages with metadata', function () {
@@ -71,9 +71,9 @@ it('can add messages with metadata', function () {
         ],
     ]);
 
-    expect($messages[0]->metadata)->toHaveKey('timestamp', '2024-01-01 10:00:00')
-        ->and($messages[1]->metadata)->toHaveKey('model', 'dall-e-3')
-        ->and($messages[1]->metadata)->toHaveKey('cost', 0.04);
+    expect($messages->get(0)->metadata)->toHaveKey('timestamp', '2024-01-01 10:00:00')
+        ->and($messages->get(1)->metadata)->toHaveKey('model', 'dall-e-3')
+        ->and($messages->get(1)->metadata)->toHaveKey('cost', 0.04);
 });
 
 it('can mix different message formats', function () {
@@ -86,10 +86,10 @@ it('can mix different message formats', function () {
     ]);
 
     expect($messages)->toHaveCount(3)
-        ->and($messages[0]->role)->toBe(MessageRole::User)
-        ->and($messages[1]->role)->toBe(MessageRole::Assistant)
-        ->and($messages[2]->role)->toBe(MessageRole::User)
-        ->and($messages[2]->metadata)->toHaveKey('urgent', true);
+        ->and($messages->get(0)->role)->toBe(MessageRole::User)
+        ->and($messages->get(1)->role)->toBe(MessageRole::Assistant)
+        ->and($messages->get(2)->role)->toBe(MessageRole::User)
+        ->and($messages->get(2)->metadata)->toHaveKey('urgent', true);
 });
 
 it('throws exception for unknown message type', function () {
@@ -108,8 +108,8 @@ it('can handle enum instances in role field', function () {
         ['role' => 'assistant', 'content' => 'Using string'],
     ]);
 
-    expect($messages[0]->role)->toBe(MessageRole::User)
-        ->and($messages[1]->role)->toBe(MessageRole::Assistant);
+    expect($messages->get(0)->role)->toBe(MessageRole::User)
+        ->and($messages->get(1)->role)->toBe(MessageRole::Assistant);
 });
 
 it('can add messages using variadic parameters', function () {
@@ -122,10 +122,10 @@ it('can add messages using variadic parameters', function () {
     );
 
     expect($messages)->toHaveCount(3)
-        ->and($messages[0]->content)->toBe('First message')
-        ->and($messages[0]->role)->toBe(MessageRole::User)
-        ->and($messages[1]->content)->toBe('Second message')
-        ->and($messages[1]->role)->toBe(MessageRole::User)
-        ->and($messages[2]->content)->toBe('Third message')
-        ->and($messages[2]->role)->toBe(MessageRole::User);
+        ->and($messages->get(0)->content)->toBe('First message')
+        ->and($messages->get(0)->role)->toBe(MessageRole::User)
+        ->and($messages->get(1)->content)->toBe('Second message')
+        ->and($messages->get(1)->role)->toBe(MessageRole::User)
+        ->and($messages->get(2)->content)->toBe('Third message')
+        ->and($messages->get(2)->role)->toBe(MessageRole::User);
 });

--- a/tests/Feature/ConversationTest.php
+++ b/tests/Feature/ConversationTest.php
@@ -18,11 +18,13 @@ it('can create conversation', function () {
 it('can add message to conversation', function () {
     $conversation = Conversation::factory()->create();
 
-    $message = $conversation->addMessage(
+    $conversation->addMessage(
         MessageRole::User,
         'Hello, world!',
         ['test' => true]
     );
+    
+    $message = $conversation->getLastMessage();
 
     expect($message->role)->toBe(MessageRole::User)
         ->and($message->content)->toBe('Hello, world!')

--- a/tests/Feature/HasAIConversationsTest.php
+++ b/tests/Feature/HasAIConversationsTest.php
@@ -74,14 +74,16 @@ it('can create a conversation and add messages', function () {
 
     $conversation = $user->startConversation(['title' => 'AI Chat']);
 
-    $userMessage = $conversation->addUserMessage('Hello AI!');
-    $assistantMessage = $conversation->addAssistantMessage('Hello! How can I help you?');
+    $conversation->addUserMessage('Hello AI!');
+    $conversation->addAssistantMessage('Hello! How can I help you?');
+    
+    $messages = $conversation->messages;
 
-    expect($conversation->messages)->toHaveCount(2)
-        ->and($userMessage->role)->toBe(MessageRole::User)
-        ->and($userMessage->content)->toBe('Hello AI!')
-        ->and($assistantMessage->role)->toBe(MessageRole::Assistant)
-        ->and($assistantMessage->content)->toBe('Hello! How can I help you?');
+    expect($messages)->toHaveCount(2)
+        ->and($messages->get(0)->role)->toBe(MessageRole::User)
+        ->and($messages->get(0)->content)->toBe('Hello AI!')
+        ->and($messages->get(1)->role)->toBe(MessageRole::Assistant)
+        ->and($messages->get(1)->content)->toBe('Hello! How can I help you?');
 });
 
 it('maintains relationship after retrieving conversation', function () {

--- a/tests/Feature/MessageDTOTest.php
+++ b/tests/Feature/MessageDTOTest.php
@@ -18,12 +18,12 @@ it('can add messages using DTOs', function () {
     ]);
 
     expect($messages)->toHaveCount(3)
-        ->and($messages[0]->role)->toBe(MessageRole::System)
-        ->and($messages[0]->content)->toBe('You are a helpful assistant')
-        ->and($messages[1]->role)->toBe(MessageRole::User)
-        ->and($messages[1]->content)->toBe('Hello!')
-        ->and($messages[2]->role)->toBe(MessageRole::Assistant)
-        ->and($messages[2]->content)->toBe('Hi there! How can I help?');
+        ->and($messages->get(0)->role)->toBe(MessageRole::System)
+        ->and($messages->get(0)->content)->toBe('You are a helpful assistant')
+        ->and($messages->get(1)->role)->toBe(MessageRole::User)
+        ->and($messages->get(1)->content)->toBe('Hello!')
+        ->and($messages->get(2)->role)->toBe(MessageRole::Assistant)
+        ->and($messages->get(2)->content)->toBe('Hi there! How can I help?');
 });
 
 it('can add messages with metadata using DTOs', function () {
@@ -34,9 +34,9 @@ it('can add messages with metadata using DTOs', function () {
         new AssistantMessage('Here is your image', ['model' => 'dall-e-3', 'cost' => 0.04]),
     ]);
 
-    expect($messages[0]->metadata)->toHaveKey('request_id', '123')
-        ->and($messages[1]->metadata)->toHaveKey('model', 'dall-e-3')
-        ->and($messages[1]->metadata)->toHaveKey('cost', 0.04);
+    expect($messages->get(0)->metadata)->toHaveKey('request_id', '123')
+        ->and($messages->get(1)->metadata)->toHaveKey('model', 'dall-e-3')
+        ->and($messages->get(1)->metadata)->toHaveKey('cost', 0.04);
 });
 
 it('can add tool messages using DTOs', function () {
@@ -47,9 +47,9 @@ it('can add tool messages using DTOs', function () {
         new ToolResultMessage('{"results": ["Laravel.com", "Laracasts.com"]}', ['call_id' => 'call_123']),
     ]);
 
-    expect($messages[0]->role)->toBe(MessageRole::ToolCall)
-        ->and($messages[1]->role)->toBe(MessageRole::ToolResult)
-        ->and($messages[0]->metadata)->toHaveKey('call_id', 'call_123');
+    expect($messages->get(0)->role)->toBe(MessageRole::ToolCall)
+        ->and($messages->get(1)->role)->toBe(MessageRole::ToolResult)
+        ->and($messages->get(0)->metadata)->toHaveKey('call_id', 'call_123');
 });
 
 it('can mix DTOs with other formats', function () {
@@ -63,10 +63,10 @@ it('can mix DTOs with other formats', function () {
     ]);
 
     expect($messages)->toHaveCount(4)
-        ->and($messages[0]->role)->toBe(MessageRole::System)
-        ->and($messages[1]->role)->toBe(MessageRole::User)
-        ->and($messages[2]->role)->toBe(MessageRole::Assistant)
-        ->and($messages[3]->role)->toBe(MessageRole::User);
+        ->and($messages->get(0)->role)->toBe(MessageRole::System)
+        ->and($messages->get(1)->role)->toBe(MessageRole::User)
+        ->and($messages->get(2)->role)->toBe(MessageRole::Assistant)
+        ->and($messages->get(3)->role)->toBe(MessageRole::User);
 });
 
 it('can use DTOs with variadic parameters', function () {
@@ -79,9 +79,9 @@ it('can use DTOs with variadic parameters', function () {
     );
 
     expect($messages)->toHaveCount(3)
-        ->and($messages[0]->content)->toBe('First question')
-        ->and($messages[1]->content)->toBe('First answer')
-        ->and($messages[2]->content)->toBe('Follow up');
+        ->and($messages->get(0)->content)->toBe('First question')
+        ->and($messages->get(1)->content)->toBe('First answer')
+        ->and($messages->get(2)->content)->toBe('Follow up');
 });
 
 it('throws exception for unknown object types', function () {

--- a/tests/Feature/MessageHelperTest.php
+++ b/tests/Feature/MessageHelperTest.php
@@ -6,7 +6,8 @@ use ElliottLawson\Converse\Models\Conversation;
 it('can add user message using helper method', function () {
     $conversation = Conversation::factory()->create();
 
-    $message = $conversation->addUserMessage('Hello from user');
+    $conversation->addUserMessage('Hello from user');
+    $message = $conversation->getLastMessage();
 
     expect($message->role)->toBe(MessageRole::User)
         ->and($message->content)->toBe('Hello from user')
@@ -16,7 +17,8 @@ it('can add user message using helper method', function () {
 it('can add assistant message using helper method', function () {
     $conversation = Conversation::factory()->create();
 
-    $message = $conversation->addAssistantMessage('Hello from assistant');
+    $conversation->addAssistantMessage('Hello from assistant');
+    $message = $conversation->getLastMessage();
 
     expect($message->role)->toBe(MessageRole::Assistant)
         ->and($message->content)->toBe('Hello from assistant')
@@ -26,7 +28,8 @@ it('can add assistant message using helper method', function () {
 it('can add system message using helper method', function () {
     $conversation = Conversation::factory()->create();
 
-    $message = $conversation->addSystemMessage('You are a helpful assistant');
+    $conversation->addSystemMessage('You are a helpful assistant');
+    $message = $conversation->getLastMessage();
 
     expect($message->role)->toBe(MessageRole::System)
         ->and($message->content)->toBe('You are a helpful assistant')
@@ -36,7 +39,8 @@ it('can add system message using helper method', function () {
 it('can add tool call message using helper method', function () {
     $conversation = Conversation::factory()->create();
 
-    $message = $conversation->addToolCallMessage('Calling weather API');
+    $conversation->addToolCallMessage('Calling weather API');
+    $message = $conversation->getLastMessage();
 
     expect($message->role)->toBe(MessageRole::ToolCall)
         ->and($message->content)->toBe('Calling weather API')
@@ -46,7 +50,8 @@ it('can add tool call message using helper method', function () {
 it('can add tool result message using helper method', function () {
     $conversation = Conversation::factory()->create();
 
-    $message = $conversation->addToolResultMessage('Weather: Sunny, 72°F');
+    $conversation->addToolResultMessage('Weather: Sunny, 72°F');
+    $message = $conversation->getLastMessage();
 
     expect($message->role)->toBe(MessageRole::ToolResult)
         ->and($message->content)->toBe('Weather: Sunny, 72°F')
@@ -74,4 +79,47 @@ it('can start streaming user using helper method', function () {
         ->and($message->content)->toBe('')
         ->and($message->is_complete)->toBeFalse()
         ->and($message->metadata)->toHaveKey('streamed', true);
+});
+
+it('can chain add message methods for fluent API', function () {
+    $conversation = Conversation::factory()->create();
+
+    $result = $conversation
+        ->addSystemMessage('You are a Laravel developer...')
+        ->addUserMessage('Implementation Context: Product and technical requirements...')
+        ->addUserMessage('Phase Context: This is phase 1 setup...')
+        ->addUserMessage('Deliverable: Please implement user authentication...');
+
+    expect($result)->toBeInstanceOf(Conversation::class)
+        ->and($conversation->messages()->count())->toBe(4)
+        ->and($conversation->messages()->system()->count())->toBe(1)
+        ->and($conversation->messages()->user()->count())->toBe(3);
+});
+
+it('can use selectRecentMessages helper', function () {
+    $conversation = Conversation::factory()->create();
+    
+    $conversation->addUserMessage('Message 1');
+    $conversation->addUserMessage('Message 2');
+    $conversation->addUserMessage('Message 3');
+
+    $subset = $conversation->selectRecentMessages(2);
+    
+    expect($subset->messages)->toHaveCount(2)
+        ->and($subset->messages->first()->content)->toBe('Message 2')
+        ->and($subset->messages->last()->content)->toBe('Message 3');
+});
+
+it('can use getRecentMessages helper', function () {
+    $conversation = Conversation::factory()->create();
+    
+    $conversation->addUserMessage('Message 1');
+    $conversation->addUserMessage('Message 2');
+    $conversation->addUserMessage('Message 3');
+
+    $messages = $conversation->getRecentMessages(2);
+    
+    expect($messages)->toHaveCount(2)
+        ->and($messages->first()->content)->toBe('Message 2')
+        ->and($messages->last()->content)->toBe('Message 3');
 });


### PR DESCRIPTION
## Summary
- Implements fluent chaining API for building conversation context
- Adds dual API approach: `add*Message()` for chaining, `create*Message()` for direct access
- Includes helper methods for message management

## Breaking Changes
⚠️ **BREAKING**: `add*Message()` methods now return `Conversation` instead of `Message` for fluent chaining.

**Migration path:**
```php
// Before
$message = $conversation->addUserMessage('Hello');

// After - use create methods for direct access
$message = $conversation->createUserMessage('Hello');

// Or use fluent chaining
$conversation = $conversation->addUserMessage('Hello');
```

## New Features

### Fluent Chaining
Perfect for building conversation context and integrating with downstream packages:
```php
$conversation
    ->addSystemMessage('You are a Laravel expert...')
    ->addUserMessage('Context: Production deployment needed')
    ->addUserMessage('Requirements: High availability, zero downtime')
    ->addUserMessage('Question: What deployment strategy do you recommend?');
```

### Helper Methods
```php
// Get most recent message
$lastMessage = $conversation->getLastMessage();

// Get recent messages collection
$recentMessages = $conversation->getRecentMessages(5);

// Create conversation subset (useful for context windows)
$subset = $conversation->selectRecentMessages(10);
```

### Dual API
- **Fluent API**: `add*Message()` returns `Conversation` for chaining
- **Direct API**: `create*Message()` returns `Message` for immediate access

## Test plan
- [x] All existing tests updated and passing
- [x] New fluent chaining tests added
- [x] Helper method tests added
- [x] README documentation updated

The fluent API enables clean integration with AI provider packages while maintaining backward compatibility through the dual API approach.