### PR TITLE
Add Conditionable trait for conditional fluent chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,143 @@ $messageId = $message->id;
 $content = $message->content;
 ```
 
+### Conditional Fluent Chaining
+
+The Conversation class uses Laravel's `Conditionable` trait, enabling powerful conditional logic in your fluent chains with `when()` and `unless()` methods. This allows you to build dynamic conversations that adapt to different contexts, user preferences, and application states.
+
+#### Basic Usage
+
+```php
+$conversation = $conversation
+    ->addSystemMessage('You are a helpful assistant')
+    ->when($user->prefers_formal_tone, function ($conversation) {
+        $conversation->addSystemMessage('Please maintain a professional and formal tone in all responses.');
+    })
+    ->when($user->language !== 'en', function ($conversation) use ($user) {
+        $conversation->addSystemMessage("Please respond in {$user->language}.");
+    })
+    ->addUserMessage($userInput);
+```
+
+#### Conditional Message Addition Based on User Preferences
+
+```php
+// Build conversation context based on user settings
+$conversation = $conversation
+    ->when($user->expert_mode, function ($conversation) {
+        $conversation->addSystemMessage('Provide detailed technical explanations with code examples.');
+    }, function ($conversation) {
+        $conversation->addSystemMessage('Explain concepts in simple terms, avoiding technical jargon.');
+    })
+    ->when($user->prefers_bullet_points, function ($conversation) {
+        $conversation->addSystemMessage('Format responses using bullet points for clarity.');
+    })
+    ->unless($user->allows_external_links, function ($conversation) {
+        $conversation->addSystemMessage('Do not include external links in responses.');
+    });
+```
+
+#### Dynamic Context Building Based on Conversation State
+
+```php
+// Add context based on conversation history
+$messageCount = $conversation->messages()->count();
+$hasCodeInHistory = $conversation->messages()
+    ->where('content', 'like', '%```%')
+    ->exists();
+
+$conversation = $conversation
+    ->when($messageCount === 0, function ($conversation) {
+        // First message - add introduction
+        $conversation->addSystemMessage('Greet the user warmly as this is their first message.');
+    })
+    ->when($messageCount > 10, function ($conversation) {
+        // Long conversation - add summary reminder
+        $conversation->addSystemMessage('This is a long conversation. Stay focused on the current topic.');
+    })
+    ->when($hasCodeInHistory, function ($conversation) {
+        // Code discussion detected
+        $conversation->addSystemMessage('Continue using the same programming language and style as earlier in the conversation.');
+    });
+```
+
+#### Conditional Tool/Function Availability
+
+```php
+// Enable tools based on user permissions and context
+$conversation = $conversation
+    ->addSystemMessage('You are an AI assistant with access to various tools.')
+    ->when($user->can('access-database'), function ($conversation) {
+        $conversation->addSystemMessage('You have access to database query tools. Use them when users ask about data.');
+    })
+    ->when($user->subscription === 'premium', function ($conversation) {
+        $conversation->addSystemMessage('You have access to advanced analysis tools including code execution and web browsing.');
+    })
+    ->unless($user->is_restricted, function ($conversation) {
+        $conversation->addSystemMessage('You can help with code generation and technical tasks.');
+    });
+```
+
+#### Environment-Specific Behavior
+
+```php
+// Adapt conversation based on application environment
+$conversation = $conversation
+    ->when(app()->environment('production'), function ($conversation) {
+        $conversation->addSystemMessage('Ensure all responses are production-safe. Do not expose sensitive information.');
+    }, function ($conversation) {
+        $conversation->addSystemMessage('Development mode: Include debugging information when relevant.');
+    })
+    ->when(config('app.demo_mode'), function ($conversation) {
+        $conversation->addSystemMessage('This is a demo. Mention feature limitations where applicable.');
+    });
+```
+
+#### Complex Conditional Logic
+
+```php
+// Build sophisticated conversation contexts with multiple conditions
+$isBusinessHours = now()->between('09:00', '17:00');
+$userTimezone = $user->timezone ?? 'UTC';
+$previousTopics = $conversation->messages()
+    ->where('role', 'user')
+    ->pluck('metadata.topic')
+    ->filter()
+    ->unique();
+
+$conversation = $conversation
+    ->when($isBusinessHours && $user->prefers_quick_responses, function ($conversation) {
+        $conversation->addSystemMessage('Provide concise responses as the user prefers quick answers during business hours.');
+    })
+    ->when($previousTopics->contains('technical'), function ($conversation) use ($previousTopics) {
+        $conversation->addSystemMessage(
+            'Previous topics discussed: ' . $previousTopics->implode(', ') . 
+            '. Maintain consistency with earlier technical discussions.'
+        );
+    })
+    ->unless($isBusinessHours, function ($conversation) use ($userTimezone) {
+        $conversation->addSystemMessage(
+            "Note: User's local time is outside business hours ({$userTimezone}). " .
+            "Be mindful they may be working late or in a different context."
+        );
+    });
+```
+
+#### Chaining Multiple Conditions
+
+The `when()` and `unless()` methods return the conversation instance, allowing unlimited chaining:
+
+```php
+$conversation = $conversation
+    ->when($conditionA, fn($c) => $c->addSystemMessage('A is true'))
+    ->when($conditionB, fn($c) => $c->addSystemMessage('B is true'))
+    ->unless($conditionC, fn($c) => $c->addSystemMessage('C is false'))
+    ->when($conditionD && $conditionE, fn($c) => $c->addSystemMessage('D and E are true'))
+    ->addUserMessage($userInput);
+```
+
+This feature enables you to build highly dynamic and context-aware conversations that adapt to user preferences, application state, and conversation history, all while maintaining clean and readable code.
+
 ### Helper Methods
 
 ```php

--- a/src/Models/Conversation.php
+++ b/src/Models/Conversation.php
@@ -14,10 +14,11 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Traits\Conditionable;
 
 class Conversation extends Model
 {
-    use HasFactory, HasUuids, SoftDeletes;
+    use Conditionable, HasFactory, HasUuids, SoftDeletes;
 
     protected $fillable = [
         'title',

--- a/tests/Feature/ConditionalFluentApiTest.php
+++ b/tests/Feature/ConditionalFluentApiTest.php
@@ -1,119 +1,104 @@
 <?php
 
-namespace ElliottLawson\Converse\Tests\Feature;
-
 use ElliottLawson\Converse\Models\Conversation;
-use ElliottLawson\Converse\Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 
-class ConditionalFluentApiTest extends TestCase
-{
-    use RefreshDatabase;
+it('can use when method to add messages conditionally', function () {
+    $conversation = Conversation::create();
+    $isNewConversation = true;
 
-    public function test_when_method_adds_messages_conditionally()
-    {
-        $conversation = Conversation::create();
-        $isNewConversation = true;
+    $conversation
+        ->when($isNewConversation, function ($conversation) {
+            $conversation->addSystemMessage('Welcome! This is your first conversation.');
+        })
+        ->addUserMessage('Hello')
+        ->when($conversation->messages()->count() > 1, function ($conversation) {
+            $conversation->addSystemMessage('Continuing conversation...');
+        });
 
-        $conversation
-            ->when($isNewConversation, function ($conversation) {
-                $conversation->addSystemMessage('Welcome! This is your first conversation.');
-            })
-            ->addUserMessage('Hello')
-            ->when($conversation->messages()->count() > 1, function ($conversation) {
-                $conversation->addSystemMessage('Continuing conversation...');
-            });
+    expect($conversation->messages)->toHaveCount(3)
+        ->and($conversation->messages->first()->content)->toBe('Welcome! This is your first conversation.')
+        ->and($conversation->messages->last()->content)->toBe('Continuing conversation...');
+});
 
-        $this->assertCount(3, $conversation->messages);
-        $this->assertEquals('Welcome! This is your first conversation.', $conversation->messages->first()->content);
-        $this->assertEquals('Continuing conversation...', $conversation->messages->last()->content);
-    }
+it('can use unless method to skip messages conditionally', function () {
+    $conversation = Conversation::create();
+    $hasExistingMessages = false;
 
-    public function test_unless_method_skips_messages_conditionally()
-    {
-        $conversation = Conversation::create();
-        $hasExistingMessages = false;
+    $conversation
+        ->unless($hasExistingMessages, function ($conversation) {
+            $conversation->addSystemMessage('Starting new conversation');
+        })
+        ->addUserMessage('What is Laravel?')
+        ->unless($conversation->messages()->count() > 5, function ($conversation) {
+            $conversation->addAssistantMessage('Laravel is a PHP framework...');
+        });
 
-        $conversation
-            ->unless($hasExistingMessages, function ($conversation) {
-                $conversation->addSystemMessage('Starting new conversation');
-            })
-            ->addUserMessage('What is Laravel?')
-            ->unless($conversation->messages()->count() > 5, function ($conversation) {
-                $conversation->addAssistantMessage('Laravel is a PHP framework...');
-            });
+    expect($conversation->messages)->toHaveCount(3);
+});
 
-        $this->assertCount(3, $conversation->messages);
-    }
+it('supports conditional with else callback', function () {
+    $conversation = Conversation::create();
+    $userPreferences = ['verbose' => true];
 
-    public function test_conditional_with_callback_parameters()
-    {
-        $conversation = Conversation::create();
-        $userPreferences = ['verbose' => true];
+    $conversation
+        ->addUserMessage('Tell me about PHP')
+        ->when($userPreferences['verbose'] ?? false,
+            function ($conversation) {
+                $conversation->addSystemMessage('Provide detailed explanations');
+            },
+            function ($conversation) {
+                $conversation->addSystemMessage('Keep responses concise');
+            }
+        );
 
-        $conversation
-            ->addUserMessage('Tell me about PHP')
-            ->when($userPreferences['verbose'] ?? false,
-                function ($conversation) {
-                    $conversation->addSystemMessage('Provide detailed explanations');
-                },
-                function ($conversation) {
-                    $conversation->addSystemMessage('Keep responses concise');
-                }
-            );
+    expect($conversation->messages->last()->content)->toBe('Provide detailed explanations');
+});
 
-        $messages = $conversation->messages;
-        $this->assertEquals('Provide detailed explanations', $messages->last()->content);
-    }
+it('handles conditional based on message count', function () {
+    $conversation = Conversation::create();
 
-    public function test_conditional_based_on_message_count()
-    {
-        $conversation = Conversation::create();
+    // First message - should trigger welcome
+    $conversation
+        ->when($conversation->messages()->count() === 0, function ($conv) {
+            $conv->addSystemMessage('Welcome to your first conversation!');
+        })
+        ->addUserMessage('Hello');
 
-        // First message - should trigger welcome
-        $conversation
-            ->when($conversation->messages()->count() === 0, function ($conv) {
-                $conv->addSystemMessage('Welcome to your first conversation!');
-            })
-            ->addUserMessage('Hello');
+    expect($conversation->messages()->count())->toBe(2);
 
-        $this->assertEquals(2, $conversation->messages()->count());
+    // Add more messages - should not trigger welcome again
+    $conversation
+        ->when($conversation->messages()->count() === 0, function ($conv) {
+            $conv->addSystemMessage('Welcome to your first conversation!');
+        })
+        ->addUserMessage('Another message');
 
-        // Add more messages - should not trigger welcome again
-        $conversation
-            ->when($conversation->messages()->count() === 0, function ($conv) {
-                $conv->addSystemMessage('Welcome to your first conversation!');
-            })
-            ->addUserMessage('Another message');
+    expect($conversation->messages()->count())->toBe(3)
+        ->and($conversation->messages()->where('content', 'Welcome to your first conversation!')->count())->toBe(1);
+});
 
-        $this->assertEquals(3, $conversation->messages()->count());
-        $this->assertEquals(1, $conversation->messages()->where('content', 'Welcome to your first conversation!')->count());
-    }
+it('enables real world scenario context building', function () {
+    $user = ['is_premium' => true, 'preferences' => ['language' => 'en']];
+    $existingConversation = false;
+    $context = 'technical_support';
 
-    public function test_real_world_scenario_context_building()
-    {
-        $user = ['is_premium' => true, 'preferences' => ['language' => 'en']];
-        $existingConversation = false;
-        $context = 'technical_support';
+    $conversation = Conversation::create(['context' => ['type' => $context]]);
 
-        $conversation = Conversation::create(['context' => ['type' => $context]]);
+    $conversation
+        ->unless($existingConversation, function ($conversation) {
+            $conversation->addSystemMessage('You are a helpful assistant.');
+        })
+        ->when($context === 'technical_support', function ($conversation) {
+            $conversation->addSystemMessage('You specialize in technical support and debugging.');
+        })
+        ->when($user['is_premium'], function ($conversation) {
+            $conversation->addSystemMessage('This is a premium user - provide priority support.');
+        })
+        ->unless($user['preferences']['language'] === 'en', function ($conversation) use ($user) {
+            $conversation->addSystemMessage("Respond in {$user['preferences']['language']}");
+        })
+        ->addUserMessage('My application is showing errors');
 
-        $conversation
-            ->unless($existingConversation, function ($conversation) {
-                $conversation->addSystemMessage('You are a helpful assistant.');
-            })
-            ->when($context === 'technical_support', function ($conversation) {
-                $conversation->addSystemMessage('You specialize in technical support and debugging.');
-            })
-            ->when($user['is_premium'], function ($conversation) {
-                $conversation->addSystemMessage('This is a premium user - provide priority support.');
-            })
-            ->unless($user['preferences']['language'] === 'en', function ($conversation) use ($user) {
-                $conversation->addSystemMessage("Respond in {$user['preferences']['language']}");
-            })
-            ->addUserMessage('My application is showing errors');
-
-        $systemMessages = $conversation->messages()->where('role', 'system')->get();
-        $this->assertCount(3, $systemMessages);
-    }
-}
+    $systemMessages = $conversation->messages()->where('role', 'system')->get();
+    expect($systemMessages)->toHaveCount(3);
+});

--- a/tests/Feature/ConditionalFluentApiTest.php
+++ b/tests/Feature/ConditionalFluentApiTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace ElliottLawson\Converse\Tests\Feature;
+
+use ElliottLawson\Converse\Models\Conversation;
+use ElliottLawson\Converse\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ConditionalFluentApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_when_method_adds_messages_conditionally()
+    {
+        $conversation = Conversation::create();
+        $isNewConversation = true;
+
+        $conversation
+            ->when($isNewConversation, function ($conversation) {
+                $conversation->addSystemMessage('Welcome! This is your first conversation.');
+            })
+            ->addUserMessage('Hello')
+            ->when($conversation->messages()->count() > 1, function ($conversation) {
+                $conversation->addSystemMessage('Continuing conversation...');
+            });
+
+        $this->assertCount(3, $conversation->messages);
+        $this->assertEquals('Welcome! This is your first conversation.', $conversation->messages->first()->content);
+        $this->assertEquals('Continuing conversation...', $conversation->messages->last()->content);
+    }
+
+    public function test_unless_method_skips_messages_conditionally()
+    {
+        $conversation = Conversation::create();
+        $hasExistingMessages = false;
+
+        $conversation
+            ->unless($hasExistingMessages, function ($conversation) {
+                $conversation->addSystemMessage('Starting new conversation');
+            })
+            ->addUserMessage('What is Laravel?')
+            ->unless($conversation->messages()->count() > 5, function ($conversation) {
+                $conversation->addAssistantMessage('Laravel is a PHP framework...');
+            });
+
+        $this->assertCount(3, $conversation->messages);
+    }
+
+    public function test_conditional_with_callback_parameters()
+    {
+        $conversation = Conversation::create();
+        $userPreferences = ['verbose' => true];
+
+        $conversation
+            ->addUserMessage('Tell me about PHP')
+            ->when($userPreferences['verbose'] ?? false,
+                function ($conversation) {
+                    $conversation->addSystemMessage('Provide detailed explanations');
+                },
+                function ($conversation) {
+                    $conversation->addSystemMessage('Keep responses concise');
+                }
+            );
+
+        $messages = $conversation->messages;
+        $this->assertEquals('Provide detailed explanations', $messages->last()->content);
+    }
+
+    public function test_conditional_based_on_message_count()
+    {
+        $conversation = Conversation::create();
+
+        // First message - should trigger welcome
+        $conversation
+            ->when($conversation->messages()->count() === 0, function ($conv) {
+                $conv->addSystemMessage('Welcome to your first conversation!');
+            })
+            ->addUserMessage('Hello');
+
+        $this->assertEquals(2, $conversation->messages()->count());
+
+        // Add more messages - should not trigger welcome again
+        $conversation
+            ->when($conversation->messages()->count() === 0, function ($conv) {
+                $conv->addSystemMessage('Welcome to your first conversation!');
+            })
+            ->addUserMessage('Another message');
+
+        $this->assertEquals(3, $conversation->messages()->count());
+        $this->assertEquals(1, $conversation->messages()->where('content', 'Welcome to your first conversation!')->count());
+    }
+
+    public function test_real_world_scenario_context_building()
+    {
+        $user = ['is_premium' => true, 'preferences' => ['language' => 'en']];
+        $existingConversation = false;
+        $context = 'technical_support';
+
+        $conversation = Conversation::create(['context' => ['type' => $context]]);
+
+        $conversation
+            ->unless($existingConversation, function ($conversation) {
+                $conversation->addSystemMessage('You are a helpful assistant.');
+            })
+            ->when($context === 'technical_support', function ($conversation) {
+                $conversation->addSystemMessage('You specialize in technical support and debugging.');
+            })
+            ->when($user['is_premium'], function ($conversation) {
+                $conversation->addSystemMessage('This is a premium user - provide priority support.');
+            })
+            ->unless($user['preferences']['language'] === 'en', function ($conversation) use ($user) {
+                $conversation->addSystemMessage("Respond in {$user['preferences']['language']}");
+            })
+            ->addUserMessage('My application is showing errors');
+
+        $systemMessages = $conversation->messages()->where('role', 'system')->get();
+        $this->assertCount(3, $systemMessages);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Laravel's `Conditionable` trait to the `Conversation` model
- Enables `when()` and `unless()` methods for building dynamic conversation contexts
- Maintains fluent API while adding powerful conditional logic capabilities

## Key Features
The Conditionable trait provides:
- `when($condition, $callback)` - Execute callback when condition is true
- `unless($condition, $callback)` - Execute callback when condition is false  
- `tap($callback)` - Execute side effects without breaking the chain

## Use Cases
This enhancement is perfect for:
- Adding welcome messages for new conversations
- Customizing system prompts based on user preferences
- Enabling features for premium users
- Adapting conversations to different contexts (support, sales, etc.)
- Building environment-specific behaviors

## Example Usage
```php
$conversation
    ->unless($existingConversation, function ($conv) {
        $conv->addSystemMessage('Welcome\! How can I help?');
    })
    ->when($user->isPremium(), function ($conv) {
        $conv->addSystemMessage('Premium support enabled');
    })
    ->unless($language === 'en', function ($conv) use ($language) {
        $conv->addSystemMessage("Respond in {$language}");
    })
    ->addUserMessage($userInput);
```

## Test Coverage
Added comprehensive tests covering:
- Basic conditional message addition
- User preference handling
- Conversation state detection
- Complex multi-condition scenarios
- Both `when()` and `unless()` methods

All existing tests continue to pass.