### PR TITLE
Add support for Laravel views in message content

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,211 @@ $conversation = $conversation
 
 These inline conditional helpers make your code more readable and concise when dealing with simple conditional logic, while `when()` and `unless()` remain available for more complex scenarios that require multiple operations or access to the conversation instance.
 
+### View Support
+
+Laravel Converse seamlessly integrates with Laravel's view system, allowing you to pass Blade views directly to message methods without needing to call `->render()`. This feature makes managing complex prompts much easier by keeping them organized in dedicated Blade files rather than cluttering your PHP code with long strings.
+
+#### Basic Usage with Views
+
+Instead of writing long prompts inline, you can now pass views directly:
+
+```php
+// Traditional approach with inline strings
+$conversation->addSystemMessage('You are an AI assistant specialized in Laravel development...');
+
+// New approach with views
+$conversation->addSystemMessage(view('prompts.laravel-expert'));
+```
+
+The view file (`resources/views/prompts/laravel-expert.blade.php`):
+```blade
+You are an AI assistant specialized in Laravel development with deep knowledge of:
+- Laravel's architecture and design patterns
+- Best practices for application structure
+- Performance optimization techniques
+- Security considerations
+- Testing strategies
+
+Always provide code examples when relevant and explain the reasoning behind your recommendations.
+```
+
+#### Passing Data to Views
+
+You can pass data to views just like in any Laravel application:
+
+```php
+// Pass user preferences and context to the view
+$conversation->addSystemMessage(
+    view('prompts.personalized-assistant', [
+        'userName' => $user->name,
+        'expertise' => $user->expertise_level,
+        'preferences' => $user->ai_preferences,
+        'language' => $user->preferred_language,
+    ])
+);
+```
+
+The view file (`resources/views/prompts/personalized-assistant.blade.php`):
+```blade
+You are a helpful assistant for {{ $userName }}.
+
+@if($expertise === 'beginner')
+    Explain concepts in simple terms and avoid technical jargon.
+@elseif($expertise === 'intermediate')
+    Provide balanced explanations with some technical details.
+@else
+    Feel free to use advanced technical terminology and dive deep into implementations.
+@endif
+
+@if($preferences->get('examples'))
+    Always include practical examples in your responses.
+@endif
+
+@if($language !== 'en')
+    Please respond in {{ $language }}.
+@endif
+```
+
+#### Using Views for Complex Prompts
+
+Views are particularly powerful for complex, multi-part prompts that would be unwieldy as strings:
+
+```php
+// Building a code review prompt with extensive guidelines
+$conversation->addSystemMessage(
+    view('prompts.code-reviewer', [
+        'standards' => $project->coding_standards,
+        'focusAreas' => ['security', 'performance', 'readability'],
+        'severity' => 'strict',
+    ])
+);
+
+// Adding user's code for review
+$conversation->addUserMessage(
+    view('prompts.review-request', [
+        'code' => $codeToReview,
+        'context' => $pullRequest->description,
+        'files' => $pullRequest->changed_files,
+    ])
+);
+```
+
+The code reviewer prompt (`resources/views/prompts/code-reviewer.blade.php`):
+```blade
+You are an expert code reviewer. Please analyze code according to these guidelines:
+
+## Coding Standards
+@foreach($standards as $standard)
+- {{ $standard->name }}: {{ $standard->description }}
+@endforeach
+
+## Focus Areas
+@foreach($focusAreas as $area)
+    @switch($area)
+        @case('security')
+            ### Security Review
+            - Check for SQL injection vulnerabilities
+            - Validate all user inputs
+            - Ensure proper authentication and authorization
+            - Look for exposed sensitive data
+            @break
+            
+        @case('performance')
+            ### Performance Review
+            - Identify N+1 query problems
+            - Check for inefficient loops
+            - Review database indexing opportunities
+            - Suggest caching strategies where appropriate
+            @break
+            
+        @case('readability')
+            ### Readability Review
+            - Ensure clear variable and function names
+            - Check for proper code organization
+            - Verify adequate comments for complex logic
+            - Suggest refactoring for overly complex methods
+            @break
+    @endswitch
+@endforeach
+
+Severity Level: {{ ucfirst($severity) }}
+@if($severity === 'strict')
+    Flag even minor issues and suggest improvements for all suboptimal patterns.
+@endif
+```
+
+#### Mixing Views and Strings
+
+You can freely mix views with regular strings in your conversation flow:
+
+```php
+$conversation
+    ->addSystemMessage(view('prompts.base-assistant'))
+    ->addSystemMessage('Additionally, today is ' . now()->format('l, F j, Y'))
+    ->addUserMessage(view('templates.question', ['topic' => $request->topic]))
+    ->when($includeContext, function ($conversation) use ($context) {
+        $conversation->addSystemMessage(view('prompts.context', compact('context')));
+    })
+    ->addUserMessage($request->question);
+```
+
+#### Using Views with Conditional Helpers
+
+Views work seamlessly with the conditional helper methods:
+
+```php
+$conversation
+    ->addMessageIf(
+        $user->wants_examples,
+        'system',
+        view('prompts.include-examples')
+    )
+    ->addMessageUnless(
+        $user->is_premium,
+        'system',
+        view('prompts.limitations.free-tier')
+    )
+    ->when($user->has_custom_instructions, function ($conversation) use ($user) {
+        $conversation->addSystemMessage(
+            view('prompts.custom-instructions', [
+                'instructions' => $user->custom_instructions
+            ])
+        );
+    });
+```
+
+#### Benefits of Using Views for Prompts
+
+1. **Organization**: Keep prompts organized in a dedicated directory structure
+2. **Reusability**: Share common prompts across different parts of your application
+3. **Maintainability**: Update prompts without touching controller logic
+4. **Version Control**: Track prompt changes separately from code changes
+5. **Blade Features**: Leverage all Blade features like includes, components, and layouts
+6. **Syntax Highlighting**: Get proper syntax highlighting in your IDE for complex prompts
+7. **Testing**: Easily test prompt generation with different data inputs
+
+Example directory structure:
+```
+resources/views/prompts/
+├── agents/
+│   ├── customer-support.blade.php
+│   ├── technical-expert.blade.php
+│   └── sales-assistant.blade.php
+├── contexts/
+│   ├── user-history.blade.php
+│   ├── session-data.blade.php
+│   └── business-rules.blade.php
+├── templates/
+│   ├── question.blade.php
+│   ├── analysis-request.blade.php
+│   └── summary-request.blade.php
+└── shared/
+    ├── base-instructions.blade.php
+    └── safety-guidelines.blade.php
+```
+
+This view support feature transforms how you manage AI prompts in your Laravel application, making them as maintainable and organized as the rest of your codebase.
+
 ### Helper Methods
 
 ```php

--- a/tests/Feature/ViewSupportTest.php
+++ b/tests/Feature/ViewSupportTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use ElliottLawson\Converse\Models\Conversation;
+use Illuminate\Support\Facades\View;
+
+beforeEach(function () {
+    // Create test views
+    View::addLocation(__DIR__.'/../fixtures/views');
+});
+
+it('can add messages using view objects', function () {
+    $conversation = Conversation::create();
+
+    // Create a mock view
+    $view = View::make('test-prompt', ['name' => 'Laravel']);
+
+    $conversation->addSystemMessage($view);
+
+    $message = $conversation->messages->first();
+    expect($message->content)->toContain('Laravel');
+});
+
+it('supports views in all message types', function () {
+    $conversation = Conversation::create();
+
+    $systemView = View::make('system-prompt');
+    $userView = View::make('user-prompt');
+    $assistantView = View::make('assistant-prompt');
+
+    $conversation
+        ->addSystemMessage($systemView)
+        ->addUserMessage($userView)
+        ->addAssistantMessage($assistantView);
+
+    expect($conversation->messages)->toHaveCount(3);
+});
+
+it('can mix views and strings', function () {
+    $conversation = Conversation::create();
+
+    $view = View::make('test-prompt', ['name' => 'World']);
+
+    $conversation
+        ->addSystemMessage('Plain text message')
+        ->addSystemMessage($view)
+        ->addUserMessage('Another plain text');
+
+    expect($conversation->messages)->toHaveCount(3)
+        ->and($conversation->messages->get(0)->content)->toBe('Plain text message')
+        ->and($conversation->messages->get(1)->content)->toContain('World');
+});
+
+it('works with create methods returning message objects', function () {
+    $conversation = Conversation::create();
+
+    $view = View::make('test-prompt', ['name' => 'Test']);
+
+    $message = $conversation->createUserMessage($view);
+
+    expect($message)->toBeInstanceOf(\ElliottLawson\Converse\Models\Message::class)
+        ->and($message->content)->toContain('Test');
+});
+
+it('supports views in conditional helpers', function () {
+    $conversation = Conversation::create();
+    $isPremium = true;
+
+    $premiumView = View::make('premium-prompt');
+
+    $conversation->addSystemMessageIf($isPremium, $premiumView);
+
+    expect($conversation->messages)->toHaveCount(1);
+});
+
+it('handles null content properly', function () {
+    $conversation = Conversation::create();
+
+    $conversation->addMessage(\ElliottLawson\Converse\Enums\MessageRole::User, null);
+
+    $message = $conversation->messages->first();
+    expect($message->content)->toBeNull()
+        ->and($message->is_complete)->toBeFalse();
+});
+
+it('demonstrates real world usage with complex prompts', function () {
+    $conversation = Conversation::create();
+
+    // User context
+    $user = [
+        'name' => 'John Doe',
+        'subscription' => 'premium',
+        'expertise' => 'intermediate',
+        'preferences' => ['verbose' => true, 'examples' => true],
+    ];
+
+    // Product context
+    $product = [
+        'name' => 'Laravel App',
+        'type' => 'SaaS',
+        'stage' => 'MVP',
+    ];
+
+    // Use views for complex prompts
+    $systemPrompt = View::make('prompts.system', compact('user'));
+    $contextPrompt = View::make('prompts.product-context', compact('product'));
+
+    $conversation
+        ->addSystemMessage($systemPrompt)
+        ->addSystemMessage($contextPrompt)
+        ->addUserMessage('How should I structure my authentication?');
+
+    expect($conversation->messages)->toHaveCount(3)
+        ->and($conversation->messages->get(0)->content)->toContain('John Doe')
+        ->and($conversation->messages->get(1)->content)->toContain('Laravel App');
+});
+
+it('properly handles view data', function () {
+    $conversation = Conversation::create();
+
+    // Test with view data
+    $data = [
+        'instructions' => ['Be helpful', 'Be concise', 'Use examples'],
+        'context' => 'technical support',
+        'priority' => 'high',
+    ];
+
+    $view = View::make('complex-prompt', $data);
+
+    $conversation->addSystemMessage($view);
+
+    $content = $conversation->messages->first()->content;
+    expect($content)->toContain('Be helpful')
+        ->and($content)->toContain('technical support')
+        ->and($content)->toContain('high');
+});
+
+// Test with actual blade syntax
+it('renders blade directives properly', function () {
+    $conversation = Conversation::create();
+
+    $view = \Illuminate\Support\Facades\Blade::render(
+        'You are helping {{ $name }} with {{ $task }}',
+        ['name' => 'Alice', 'task' => 'Laravel development']
+    );
+
+    $conversation->addSystemMessage($view);
+
+    expect($conversation->messages->first()->content)
+        ->toBe('You are helping Alice with Laravel development');
+});
+
+it('works with inline blade templates', function () {
+    $conversation = Conversation::create();
+
+    $requirements = ['Fast performance', 'Clean code', 'Good documentation'];
+
+    $view = \Illuminate\Support\Facades\Blade::render(
+        '@foreach($requirements as $req)- {{ $req }}
+@endforeach',
+        compact('requirements')
+    );
+
+    $conversation->addSystemMessage($view);
+
+    $content = $conversation->messages->first()->content;
+    expect($content)->toContain('- Fast performance')
+        ->and($content)->toContain('- Clean code')
+        ->and($content)->toContain('- Good documentation');
+});

--- a/tests/fixtures/views/assistant-prompt.blade.php
+++ b/tests/fixtures/views/assistant-prompt.blade.php
@@ -1,0 +1,1 @@
+This is an assistant response from a view.

--- a/tests/fixtures/views/complex-prompt.blade.php
+++ b/tests/fixtures/views/complex-prompt.blade.php
@@ -1,0 +1,7 @@
+Instructions:
+@foreach($instructions as $instruction)
+- {{ $instruction }}
+@endforeach
+
+Context: {{ $context }}
+Priority: {{ $priority }}

--- a/tests/fixtures/views/premium-prompt.blade.php
+++ b/tests/fixtures/views/premium-prompt.blade.php
@@ -1,0 +1,1 @@
+Premium support is enabled. You have access to advanced features.

--- a/tests/fixtures/views/prompts/product-context.blade.php
+++ b/tests/fixtures/views/prompts/product-context.blade.php
@@ -1,0 +1,6 @@
+Product Context:
+- Name: {{ $product['name'] }}
+- Type: {{ $product['type'] }}
+- Stage: {{ $product['stage'] }}
+
+Focus on {{ $product['stage'] === 'MVP' ? 'rapid development and core features' : 'scalability and optimization' }}.

--- a/tests/fixtures/views/prompts/system.blade.php
+++ b/tests/fixtures/views/prompts/system.blade.php
@@ -1,0 +1,13 @@
+You are assisting {{ $user['name'] }}.
+@if($user['subscription'] === 'premium')
+This is a premium user - provide priority support.
+@endif
+@if($user['expertise'] === 'intermediate')
+Provide balanced explanations suitable for intermediate level.
+@endif
+@if($user['preferences']['verbose'] ?? false)
+Provide detailed, comprehensive responses.
+@endif
+@if($user['preferences']['examples'] ?? false)
+Include practical examples in your responses.
+@endif

--- a/tests/fixtures/views/system-prompt.blade.php
+++ b/tests/fixtures/views/system-prompt.blade.php
@@ -1,0 +1,1 @@
+You are a helpful assistant.

--- a/tests/fixtures/views/test-prompt.blade.php
+++ b/tests/fixtures/views/test-prompt.blade.php
@@ -1,0 +1,1 @@
+Hello {{ $name }}! This is a test prompt.

--- a/tests/fixtures/views/user-prompt.blade.php
+++ b/tests/fixtures/views/user-prompt.blade.php
@@ -1,0 +1,1 @@
+This is a user message from a view.


### PR DESCRIPTION
## Summary
- Adds native support for passing Laravel View objects to all message methods
- Automatically renders views to strings internally
- No breaking changes - string content still works as before

## Key Changes
- Updated all message methods to accept `string|View` union type instead of just `string`
- Added `normalizeContent()` helper method to handle View rendering
- Works with all APIs: fluent, direct, and conditional helpers
- Comprehensive test coverage with fixture views

## Before & After
```php
// Before - manual render() required
$conversation->addSystemMessage(view('prompts.expert')->render());

// After - pass view directly
$conversation->addSystemMessage(view('prompts.expert'));
```

## Benefits
This enhancement makes managing complex AI prompts much easier:

- **Organization**: Keep prompts in Blade files, not inline strings
- **Blade Features**: Use conditionals, loops, includes, components
- **Version Control**: Track prompt changes separately from code
- **Syntax Highlighting**: Full IDE support for Blade files
- **Reusability**: Share prompts across different conversations
- **Testing**: Easier to test prompts in isolation

## Example Usage
```php
// Complex prompt with data
$conversation->addSystemMessage(
    view('prompts.code-reviewer', [
        'language' => 'PHP',
        'standards' => ['PSR-12', 'Laravel conventions'],
        'focus' => ['security', 'performance']
    ])
);

// Works with conditional helpers too
$conversation->addSystemMessageIf(
    $user->wantsDetailedResponses(),
    view('prompts.verbose-mode')
);

// Mix views and strings freely
$conversation
    ->addSystemMessage(view('prompts.base-personality'))
    ->addSystemMessage('Additional context here')
    ->addUserMessage($request->input('message'));
```

## Test Coverage
Added comprehensive tests including:
- Basic view rendering
- Passing data to views  
- Mixing views and strings
- Conditional helper support
- Complex Blade directives
- Inline Blade templates

All existing tests continue to pass.