### PR TITLE
Add Packagist total downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Tests](https://github.com/elliottlawson/converse/actions/workflows/tests.yml/badge.svg)](https://github.com/elliottlawson/converse/actions/workflows/tests.yml)
 [![Latest Stable Version](https://poser.pugx.org/elliottlawson/converse/v/stable)](https://packagist.org/packages/elliottlawson/converse)
+[![Total Downloads](https://poser.pugx.org/elliottlawson/converse/downloads)](https://packagist.org/packages/elliottlawson/converse)
 [![License](https://poser.pugx.org/elliottlawson/converse/license)](https://packagist.org/packages/elliottlawson/converse)
 
 A Laravel package for storing and managing AI conversation history with any LLM provider. Built to handle the real-world needs of AI-powered applications, including streaming responses, function calling, and conversation branching.


### PR DESCRIPTION
## Summary
Adds the Packagist total downloads badge to the README badges section.

## Changes
- Added `[\![Total Downloads](https://poser.pugx.org/elliottlawson/converse/downloads)]` badge
- Positioned between version and license badges for consistent ordering

This helps show the package's adoption and usage in the Laravel community.