### PR TITLE
Remove non-existent send() method from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **AI SDKs are great at sending messages, but terrible at having conversations.** 
 
-Converse makes AI conversations flow as naturally as Eloquent makes database queries. Instead of manually managing message arrays and context for every API call, you just write `$conversation->addUserMessage('Hello')->send()`. The entire conversation history, context management, and message formatting is handled automatically.
+Converse makes AI conversations flow as naturally as Eloquent makes database queries. Instead of manually managing message arrays and context for every API call, you just write `$conversation->addUserMessage('Hello')`. The entire conversation history, context management, and message formatting is handled automatically.
 
 ## 📚 Documentation
 
@@ -48,7 +48,7 @@ With Converse, conversations just flow:
 
 ```php
 // Context is automatic ✨
-$conversation->addUserMessage($newMessage)->send();
+$conversation->addUserMessage($newMessage);
 ```
 
 That's it. **It's the difference between sending messages and actually having a conversation.**
@@ -98,7 +98,7 @@ $conversation
     ->addAssistantMessage('Hi! How can I help you today?');
 
 // Continue the conversation anytime
-$conversation->addUserMessage('Tell me about Laravel')->send();
+$conversation->addUserMessage('Tell me about Laravel');
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -90,9 +90,7 @@ class User extends Model
 Start having conversations:
 
 ```php
-$conversation = $user->startConversation(['title' => 'My Chat']);
-
-$conversation
+$conversation = $user->startConversation(['title' => 'My Chat'])
     ->addSystemMessage('You are a helpful assistant')
     ->addUserMessage('Hello!')
     ->addAssistantMessage('Hi! How can I help you today?');

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ With Converse, conversations just flow:
 ```php
 // Context is automatic ✨
 $conversation->addUserMessage($newMessage);
+
+// Your AI call gets the full context
+$response = $aiClient->chat([
+    'messages' => $conversation->messages->toArray()
+]);
+
+// Store the response
+$conversation->addAssistantMessage($response->content);
 ```
 
 That's it. **It's the difference between sending messages and actually having a conversation.**
@@ -90,13 +98,19 @@ class User extends Model
 Start having conversations:
 
 ```php
+// Build the conversation context
 $conversation = $user->startConversation(['title' => 'My Chat'])
     ->addSystemMessage('You are a helpful assistant')
-    ->addUserMessage('Hello!')
-    ->addAssistantMessage('Hi! How can I help you today?');
+    ->addUserMessage('Hello! What is Laravel?');
 
-// Continue the conversation anytime
-$conversation->addUserMessage('Tell me about Laravel');
+// Make your API call to OpenAI, Anthropic, etc.
+$response = $yourAiClient->chat([
+    'messages' => $conversation->messages->toArray(),
+    // ... other AI configuration
+]);
+
+// Store the AI's response
+$conversation->addAssistantMessage($response->content);
 ```
 
 ## Requirements

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,10 +62,19 @@ class User extends Model
 Start a conversation:
 
 ```php
+// Build the conversation context
 $conversation = $user->startConversation(['title' => 'My Chat'])
     ->addSystemMessage('You are a helpful assistant')
-    ->addUserMessage('Hello!')
-    ->addAssistantMessage('Hi! How can I help you today?');
+    ->addUserMessage('Hello! What is Laravel?');
+
+// Make your API call to OpenAI, Anthropic, etc.
+$response = $yourAiClient->chat([
+    'messages' => $conversation->messages->toArray(),
+    // ... other AI configuration
+]);
+
+// Store the AI's response
+$conversation->addAssistantMessage($response->content);
 ```
 
 [Learn more in the documentation →](/guide/getting-started)
@@ -96,6 +105,14 @@ With Converse, conversations just flow:
 ```php
 // Context is automatic
 $conversation->addUserMessage($newMessage);
+
+// Your AI call gets the full context
+$response = $aiClient->chat([
+    'messages' => $conversation->messages->toArray()
+]);
+
+// Store the response
+$conversation->addAssistantMessage($response->content);
 ```
 
 That's it. The entire conversation history, context management, and message formatting is handled automatically. **It's the difference between sending messages and actually having a conversation.** 

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,9 +62,7 @@ class User extends Model
 Start a conversation:
 
 ```php
-$conversation = $user->startConversation(['title' => 'My Chat']);
-
-$conversation
+$conversation = $user->startConversation(['title' => 'My Chat'])
     ->addSystemMessage('You are a helpful assistant')
     ->addUserMessage('Hello!')
     ->addAssistantMessage('Hi! How can I help you today?');
@@ -97,7 +95,7 @@ With Converse, conversations just flow:
 
 ```php
 // Context is automatic
-$conversation->addUserMessage($newMessage)->send();
+$conversation->addUserMessage($newMessage);
 ```
 
 That's it. The entire conversation history, context management, and message formatting is handled automatically. **It's the difference between sending messages and actually having a conversation.** 


### PR DESCRIPTION
The README examples showed a send() method that doesn't exist in the package. This was misleading as it suggested the package includes methods for sending messages to AI providers, when it's actually focused on storing and managing conversation history.