### PR TITLE
refactor: make upgrade command specific to UUID migration

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -29,7 +29,7 @@ That's it! Converse is now installed with sensible defaults.
 If you installed Converse before version 0.1.5, run:
 
 ```bash
-php artisan converse:upgrade
+php artisan converse:upgrade-uuid
 ```
 
 This command:

--- a/src/Commands/UpgradeCommand.php
+++ b/src/Commands/UpgradeCommand.php
@@ -10,9 +10,9 @@ use Illuminate\Support\Str;
 
 class UpgradeCommand extends Command
 {
-    protected $signature = 'converse:upgrade';
+    protected $signature = 'converse:upgrade-uuid';
 
-    protected $description = 'Upgrade Converse database schema to the latest version';
+    protected $description = 'Add UUID support to existing messages table';
 
     public function handle(): int
     {


### PR DESCRIPTION
## Summary
- Change upgrade command to be specific: `converse:upgrade-uuid`
- This allows for future upgrade commands without conflicts

## Changes
- Updated command signature from `converse:upgrade` to `converse:upgrade-uuid`
- Updated command description to be specific about UUID functionality
- Updated documentation to reflect new command name

## Why?
As discussed, having a general `converse:upgrade` command could cause conflicts if we need other upgrade paths in the future. Making it specific to the UUID upgrade allows us to add other upgrade commands like `converse:upgrade-indexes`, `converse:upgrade-columns`, etc. without conflicts.