### PR TITLE
docs: add Prism callout sections to README and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ $response = $yourAiClient->chat([
 $conversation->addAssistantMessage($response->content);
 ```
 
+## Looking for an AI Client?
+
+Using [Prism](https://github.com/echolabs/prism-php)? Try out [Converse-Prism](https://github.com/elliottlawson/converse-prism) - a seamless integration that combines Prism's elegant AI client with Converse's conversation management.
+
 ## Requirements
 
 - PHP 8.2+

--- a/docs/index.md
+++ b/docs/index.md
@@ -79,6 +79,10 @@ $conversation->addAssistantMessage($response->content);
 
 [Learn more in the documentation →](/guide/getting-started)
 
+## Looking for an AI Client?
+
+Using [Prism](https://github.com/echolabs/prism-php) for your AI integrations? Check out [Converse-Prism](https://github.com/elliottlawson/converse-prism) for a seamless integration between both packages.
+
 ## The Difference
 
 Without Converse, every API call means manually rebuilding context:


### PR DESCRIPTION
## Summary
Add simple call-to-action sections that promote Prism PHP and the Converse-Prism integration package.

## Changes
- Added "Looking for an AI Client?" section to README.md
- Added similar section to documentation homepage
- Links to both Prism PHP and the Converse-Prism integration

## Why?
This provides a gentle nudge for users who might be looking for an AI client to check out Prism, and if they're using Prism, to try the Converse-Prism integration package.

The sections are brief and don't duplicate any documentation - just simple callouts with links.