### PR TITLE
fix: correct Prism repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $conversation->addAssistantMessage($response->content);
 
 ## Looking for an AI Client?
 
-Using [Prism](https://github.com/echolabs/prism-php)? Try out [Converse-Prism](https://github.com/elliottlawson/converse-prism) - a seamless integration that combines Prism's elegant AI client with Converse's conversation management.
+Using [Prism](https://github.com/prism-php/prism)? Try out [Converse-Prism](https://github.com/elliottlawson/converse-prism) - a seamless integration that combines Prism's elegant AI client with Converse's conversation management.
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ $conversation->addAssistantMessage($response->content);
 
 ## Looking for an AI Client?
 
-Using [Prism](https://github.com/echolabs/prism-php) for your AI integrations? Check out [Converse-Prism](https://github.com/elliottlawson/converse-prism) for a seamless integration between both packages.
+Using [Prism](https://github.com/prism-php/prism) for your AI integrations? Check out [Converse-Prism](https://github.com/elliottlawson/converse-prism) for a seamless integration between both packages.
 
 ## The Difference
 


### PR DESCRIPTION
## Summary
Fix incorrect Prism repository link in README and documentation.

## Changes
- Changed link from `https://github.com/echolabs/prism-php` to `https://github.com/prism-php/prism`
- Updated in both README.md and docs/index.md

## Why?
The previous link was incorrect. The correct repository for Prism is at https://github.com/prism-php/prism.